### PR TITLE
Changed "parse-date" to "date-parse".

### DIFF
--- a/example-site/dragonfly-framework/dragonfly.lsp
+++ b/example-site/dragonfly-framework/dragonfly.lsp
@@ -99,6 +99,9 @@
 	(constant (global 'write) write-buffer)
 ) 
 
+(when (< (sys-info -2) 10300)
+	(constant (global 'date-parse) parse-date))
+
 ;===============================================================================
 ; !Basic Setup, Global Vars, and Sanity Checks
 ;===============================================================================

--- a/example-site/dragonfly-framework/plugins-active/dragonfly_basic.lsp
+++ b/example-site/dragonfly-framework/plugins-active/dragonfly_basic.lsp
@@ -353,7 +353,7 @@
 			(dolist (idx entry-index (= max-items $idx)) 
 				
 				(set 'entry (sxml idx))
-				(set 'dateseconds (parse-date (lookup 'updated entry) "%Y-%m-%dT%H:%M:%SZ")) ; convert string date to seconds
+				(set 'dateseconds (date-parse (lookup 'updated entry) "%Y-%m-%dT%H:%M:%SZ")) ; convert string date to seconds
 
 				(set 'contenthtml (lookup 'content entry))
 				(replace "&lt;br/&gt;" contenthtml "<br/>") ; we need to replace some html entities

--- a/example-site/dragonfly-framework/plugins-inactive/dragonfly_twitter.lsp
+++ b/example-site/dragonfly-framework/plugins-inactive/dragonfly_twitter.lsp
@@ -48,7 +48,7 @@
 	)
 	(dolist (idx entry-index)
 		(set 'entry (sxml idx))
-		(set 'dateseconds (parse-date (lookup 'published entry) "%Y-%m-%dT%H:%M:%SZ")) ; convert string date to seconds
+		(set 'dateseconds (date-parse (lookup 'published entry) "%Y-%m-%dT%H:%M:%SZ")) ; convert string date to seconds
 		
 		(println
 			"<div class='entry'>"


### PR DESCRIPTION
Hi @taoeffect, 

This changes `parse-date` (deprecated in newLISP 10.3) to `date-parse` and adds backwards compatibility.

`if-not` and `local` were both deprecated in or before 10.4.3. However, `if-not` will remain functional indefinitely, and `local` has yet to be removed.

-dm